### PR TITLE
Features device online/offline status and image stale alert

### DIFF
--- a/app/Device.php
+++ b/app/Device.php
@@ -207,7 +207,7 @@ class Device extends Model
     public function scopePublicDashData($query)
     {
         return $query->select([
-            'id',
+            'devices.id',
             'name',
             'location_id',
             'cover_command',
@@ -218,6 +218,7 @@ class Device extends Model
             'image_rate',
             'sensor_rate',
             'last_network_update_at',
+            'image.updated_at as image_updated_at',
         ]);
     }
     

--- a/app/Device.php
+++ b/app/Device.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Spatie\Activitylog\Traits\LogsActivity;
-//use Spatie\Activitylog\Traits\CausesActivity;
-use App\Sensor;
-use App\SensorData;
 
 class Device extends Model
 {
@@ -23,7 +20,8 @@ class Device extends Model
      * @var array
      */
     protected $dates = [
-        'deleted_at'
+        'deleted_at',
+        'last_network_update_at'
     ];
     
     /**
@@ -42,7 +40,7 @@ class Device extends Model
         'name', 'location_id', 'uuid', 'version', 'hostname', 'ip', 'mac_address', 
         'time', 'cover_command', 'cover_status', 'error_msg', 'limitsw_open', 'limitsw_closed',
         'light_in', 'light_out', 'update_rate', 'image_rate', 'sensor_rate', 
-        'open_time', 'close_time'
+        'open_time', 'close_time', 'last_network_update_at',
     ];
     
     /**
@@ -177,6 +175,17 @@ class Device extends Model
     }
     
     /**
+     * Accessor: Get the last time the server received and update call from the device converted to a
+     * user friendly format. The format is Month day 12hour:mins am/pm and will be in the user's preferred timezone
+     *
+     * @return string
+     */
+    public function getLastNetworkUpdateAtHumanAttribute()
+    {
+        return $this->last_network_update_at->setTimezone(Auth::user()->timezone)->format('M j g:i a');
+    }
+    
+    /**
      * Scope a query to only include devices belonging to a given location
      *
      * @param \Illuminate\Database\Eloquent\Builder $query
@@ -208,6 +217,7 @@ class Device extends Model
             'update_rate',
             'image_rate',
             'sensor_rate',
+            'last_network_update_at',
         ]);
     }
     
@@ -259,7 +269,7 @@ class Device extends Model
     }
     
     /**
-     * Check if the device is ready for a command
+     * Check if the device is ready for a cover command
      *
      * @return boolean
      */

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -11,6 +11,7 @@ use App\Sensor;
 use App\SensorData;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Carbon\Carbon;
 
 class ApiController extends Controller
 {
@@ -81,6 +82,7 @@ class ApiController extends Controller
         $device->cpu_temp = $request->input('cpu_temp');
         $device->temperature = $request->input('temperature');
         $device->humidity = $request->input('humidity');
+        $device->last_network_update_at = Carbon::now();
         
         $device->save();
         

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -70,6 +70,7 @@ class DashboardController extends Controller
             ->get();
         //Get all devices for the selected location
         $devices = Device::publicDashData()
+            ->leftJoin('deviceimages as image', 'devices.id', '=', 'image.device_id')
             ->where('location_id', '=', $locations[0]->id ?? 0)
             ->orderBy('name', 'ASC')
             ->paginate(4);
@@ -91,6 +92,16 @@ class DashboardController extends Controller
                 //Mark the device as stale if the device has missed three updates plus a minute
                 $deviceStaleMins = ceil(($item->update_rate * 3) / 60) + 1;
                 $item['isDeviceStale'] = ($item->last_network_update_at <= Carbon::now()->subMinute($deviceStaleMins)) ? true : false;
+    
+                //Mark the device image as stale if the device has missed three image updates plus a minute
+                if ($item->image_updated_at != null)
+                {
+                    $imageStaleMins = ceil(($item->image_rate * 3) / 60) + 1;
+                    $item['isImageStale'] = ($item->image_updated_at <= Carbon::now()->subMinute($imageStaleMins)) ? true : false;
+                }
+                else
+                    $item['isImageStale'] = false;
+                
                 return $item;
             });
         }

--- a/database/migrations/2017_10_27_203111_add_last_network_update_at_to_device_table.php
+++ b/database/migrations/2017_10_27_203111_add_last_network_update_at_to_device_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Carbon\Carbon;
+
+class AddLastNetworkUpdateAtToDeviceTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dateTime('last_network_update_at')->default(Carbon::now());
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('last_network_update_at');
+        });
+    }
+}

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -36,6 +36,24 @@ Dashboard
 	font-weight: 500;
 }
 
+.alert-image-stale
+{
+	position:absolute;
+	margin-left: auto;
+	margin-right: auto;
+	padding-top: 4px;
+	padding-bottom: 4px;
+	bottom: 34px;
+	left: 0;
+	right: 0;
+	z-index:5;
+}
+
+.relative
+{
+	position: relative;
+}
+
 /*
 ======================================
 Dashboard Image Modal

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -22,6 +22,20 @@ Dashboard
 	margin-right: 10px;
 }
 
+.status-online
+{
+	color: #07a800;
+	font-size: .86em;
+	font-weight: 500;
+}
+
+.status-offline
+{
+	color: #df0000;
+	font-size: .86em;
+	font-weight: 500;
+}
+
 /*
 ======================================
 Dashboard Image Modal

--- a/public/js/dashboard/update_page.js
+++ b/public/js/dashboard/update_page.js
@@ -175,22 +175,28 @@ function updateDashboardData(targetURL, targetData)
 
 //Change the selected device for the page
 $deviceTableHolder.on('click', '[data-view]', function () {
-	let arrayNum = $(this).attr("data-view");
-	let device_id = $(this).attr("data-device-id");
+	if (!lock)
+	{
+		lock = true;
+		let arrayNum = $(this).attr("data-view");
+		let device_id = $(this).attr("data-device-id");
 
-	//Set the device image url, sensor values, and the device header name
-	updateActiveDeviceInfo(devices[arrayNum]);
+		//Set the device image url, sensor values, and the device header name
+		updateActiveDeviceInfo(devices[arrayNum]);
 
-	//Set the rate for the image to be updated at
-	setImageUpdateRate(devices[arrayNum]['image_rate']);
+		//Set the rate for the image to be updated at
+		setImageUpdateRate(devices[arrayNum]['image_rate']);
 
-	//Disable the selected view button and enable the previously disabled view button
-	$(this).prop("disabled", true);
-	$disabledViewBtn.prop("disabled", false);
-	$disabledViewBtn = $(this);
+		//Disable the selected view button and enable the previously disabled view button
+		$(this).prop("disabled", true);
+		$disabledViewBtn.prop("disabled", false);
+		$disabledViewBtn = $(this);
 
-	//Store the current device's id
-	currentDeviceId = device_id;
+		//Store the current device's id
+		currentDeviceId = device_id;
+
+		lock = false;
+	}
 });
 
 //Update the site dropdown list

--- a/public/js/dashboard/update_page.js
+++ b/public/js/dashboard/update_page.js
@@ -19,6 +19,10 @@ let $alertSuccessBar = $('#alert_success_bar');
 let $alertSuccessText = $('#success_bar_text');
 let $alertFailureBar = $('#alert_failure_bar');
 let $alertFailureText = $('#failure_bar_text');
+//Image alert bar
+let $alertImageBar = $('#alert_stale_image_bar');
+let $alertImageText = $('#image_stale_bar_text');
+let userExitImageAlert = false;
 //Update rates
 let dashUpdateRate = 5000;
 let imageUpdateRate = 30000;
@@ -67,6 +71,7 @@ function refreshDashboardData()
 
 //Change site
 $siteList.on('click', 'li[data-site-id]', function () {
+	resetImageAlert();
 	let targetURL = '/dashboard';
 	let targetData = {site_id: $(this).attr("data-site-id")};
 	updateDashboardData(targetURL, targetData);
@@ -74,6 +79,7 @@ $siteList.on('click', 'li[data-site-id]', function () {
 
 //Change location
 $locationList.on('click', 'li[data-location-id]', function () {
+	resetImageAlert();
 	let targetURL = '/dashboard';
 	let targetData = {location_id: $(this).attr("data-location-id"), site_id: currentSiteId};
 	updateDashboardData(targetURL, targetData);
@@ -81,6 +87,7 @@ $locationList.on('click', 'li[data-location-id]', function () {
 
 //Change the device pagination page
 $deviceTableHolder.on('click', '#pagination_links', function (e) {
+	resetImageAlert();
 	//Prevent the normal link redirect
 	e.preventDefault();
 	let $clickedElement = $(event.target);
@@ -143,6 +150,10 @@ function updateDashboardData(targetURL, targetData)
 				//Set the rate for the image to be updated at
 				setImageUpdateRate(activeDevice['image_rate']);
 
+				//Alert the user if the image for the selected device is stale
+				if (activeDevice['isImageStale'] && !userExitImageAlert)
+					alertImageBarActivate();
+
 				//Update the stored active site, location, and device IDs
 				currentSiteId = activeSite['id'];
 				currentLocationId = activeLocation['id'];
@@ -191,6 +202,14 @@ $deviceTableHolder.on('click', '[data-view]', function () {
 		$(this).prop("disabled", true);
 		$disabledViewBtn.prop("disabled", false);
 		$disabledViewBtn = $(this);
+
+		//Reset the user exiting the stale image alert
+		userExitImageAlert = false;
+		//Alert the user if the image for the selected device is stale
+		if (devices[arrayNum]['isImageStale'] && !userExitImageAlert)
+			alertImageBarActivate();
+		else
+			$alertImageBar.trigger("click");
 
 		//Store the current device's id
 		currentDeviceId = device_id;
@@ -321,6 +340,13 @@ function setImageUpdateRate(time)
 		imageUpdateRate = formattedTime;
 }
 
+//Reset the user exiting the stale image alert
+function resetImageAlert()
+{
+	userExitImageAlert = false;
+	$alertImageBar.trigger("click");
+}
+
 //Display the alert bar with the given message
 function alertBarActivate(message, type)
 {
@@ -344,4 +370,18 @@ $alertSuccessBar.on('click', function () {
 //Hide the failure alert bar
 $alertFailureBar.on('click', function () {
 	$alertFailureBar.hide();
+});
+
+//Display the image alert bar
+function alertImageBarActivate()
+{
+	$alertImageText.html('<strong>Warning!</strong> This image is stale');
+	$alertImageBar.show();
+}
+
+//Hide the failure alert bar
+$alertImageBar.on('click', function ()
+{
+	$alertImageBar.hide();
+	userExitImageAlert = true;
 });

--- a/resources/views/dashboard/device_list.blade.php
+++ b/resources/views/dashboard/device_list.blade.php
@@ -9,7 +9,17 @@
 		<tbody id="control_devices_list">
 		@foreach ($devices as $device)
 			<tr id="tr_{{ $device->id }}">
-				<td>{{ $device->name }}</td>
+				<td>
+					<b><a href="{{ route('device.show', $device->id) }}">{{ $device->name }}</a></b>
+					@if($device->isDeviceStale)
+						<p class="status-offline">Last Seen
+							<br>
+							{{ $device->lastNetworkUpdateAtHuman }}
+						</p>
+					@else
+						<p class="status-online">Online</p>
+					@endif
+				</td>
 				<td>
 					<div class="btn-group btn-group-sm" role="group" style="display: block">
 						@if($device->id == $active_data['device']['id'])

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -59,7 +59,12 @@
 			</div>
 		</div>
 		<div class="row">
-			<div class="col-md-5 col-md-offset-1 text-center">
+			<div class="col-md-5 col-md-offset-1 text-center relative">
+				<!-- Image alert bar -->
+				<div class="alert alert-warning alert-dismissible alert-image-stale" role="alert" id="alert_stale_image_bar" hidden>
+					<button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+					<div id="image_stale_bar_text"></div>
+				</div>
 				<!-- Triggers the Image Modal -->
 				<input class="border-simple img-responsive" type="image" src="{{ URL('image/device') . '/' . ($active_data['device']->id ?? 0) }}" alt="Device Image" id="deviceImage" data-toggle="modal" data-target="#image_modal"/>
 				<br>


### PR DESCRIPTION
This pull request adds two features to the dashboard:

1. Display the devices status underneath its name #86 
![offline-online](https://user-images.githubusercontent.com/16866862/32480008-846be33e-c341-11e7-8ea4-89bb873add05.JPG)

2. Display a warning alert on the device image when the image is stale #20 
![image-stale](https://user-images.githubusercontent.com/16866862/32480026-9b8d61f0-c341-11e7-9242-bfe4aa80fc6b.JPG)

The device status will display last seen date time when the device misses three updates (based on update_rate) plus a minute. The image alert will display when the device has missed three image updates (based on image_rate) plus a minute.

Note: Empty cache and run `php artisan migrate` before testing
