### PR TITLE
Fix last network update at getting assigned the wrong value at creation

### DIFF
--- a/database/migrations/2017_11_10_020716_re_add_last_network_update_at_to_devices_table.php
+++ b/database/migrations/2017_11_10_020716_re_add_last_network_update_at_to_devices_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ReAddLastNetworkUpdateAtToDevicesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('last_network_update_at');
+        });
+        Schema::table('devices', function (Blueprint $table) {
+            $table->timestamp('last_network_update_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('last_network_update_at');
+        });
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dateTime('last_network_update_at')->default(Carbon::now());
+        });
+    }
+}


### PR DESCRIPTION
Change the attribute to be a timestamp that is set to the current date and time at creation. Then is updated for each api update call. Fixes issue #108 