### PR TITLE
Improve performance of device.show and sensor.show pages

### DIFF
--- a/app/Device.php
+++ b/app/Device.php
@@ -112,6 +112,20 @@ class Device extends Model
     }
     
     /**
+     * Accessor: Get the open time of the device converted to the users preferred time and
+     * converted to a user friendly format of h:i a
+     *
+     * @return string
+     */
+    public function getOpenTimeHumanAttribute()
+    {
+        $time = new Carbon($this->attributes['open_time'], 'UTC');
+        $time = $time->setTimezone(Auth::user()->timezone);
+        
+        return $time->format('h:i a');
+    }
+    
+    /**
      * Accessor: Get the close time of the device converted to hours and minutes
      * If it is a device accessing the time use UTC
      * If it is a user accessing the time use their preferred timezone
@@ -128,6 +142,20 @@ class Device extends Model
             $time = $time->setTimezone(Auth::user()->timezone);
         
         return $time->format('H:i');
+    }
+    
+    /**
+     * Accessor: Get the close time of the device converted to the users preferred time and
+     * converted to a user friendly format of h:i a
+     *
+     * @return string
+     */
+    public function getCloseTimeHumanAttribute()
+    {
+        $time = new Carbon($this->attributes['close_time'], 'UTC');
+        $time = $time->setTimezone(Auth::user()->timezone);
+        
+        return $time->format('h:i a');
     }
     
     /**
@@ -183,6 +211,39 @@ class Device extends Model
     public function getLastNetworkUpdateAtHumanAttribute()
     {
         return $this->last_network_update_at->setTimezone(Auth::user()->timezone)->format('M j g:i a');
+    }
+    
+    /**
+     * Accessor: Get the last time the server received and update call from the device converted to a
+     * user friendly detailed format. The format is Month day, year 12hour:mins am/pm and will be in the user's preferred timezone
+     *
+     * @return string
+     */
+    public function getLastNetworkUpdateAtDetailedAttribute()
+    {
+        return $this->last_network_update_at->setTimezone(Auth::user()->timezone)->format('M j, Y g:i a');
+    }
+    
+    /**
+     * Accessor: Get the devices last update time converted to a
+     * user friendly format. The format is Month day, year 12hour:mins am/pm and will be in the user's preferred timezone
+     *
+     * @return string
+     */
+    public function getUpdatedAtHumanAttribute()
+    {
+        return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M j, Y g:i a');
+    }
+    
+    /**
+     * Accessor: Get the devices created at time converted to a
+     * user friendly format. The format is Month day, year 12hour:mins am/pm and will be in the user's preferred timezone
+     *
+     * @return string
+     */
+    public function getCreatedAtHumanAttribute()
+    {
+        return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M j, Y g:i a');
     }
     
     /**

--- a/app/Http/Controllers/SensorController.php
+++ b/app/Http/Controllers/SensorController.php
@@ -71,15 +71,17 @@ class SensorController extends Controller
     public function show(Request $request, $id)
     {
         $sensor = Sensor::findOrFail($id);
+        $latestData = $sensor->latestData;
         $sensordata = $sensor->data()->orderBy('id', 'desc')->paginate(25);
+        $chartSensorData = $sensordata->reverse();
         $chart = Charts::create('line', 'highcharts')
             ->title($sensor->name)
             ->elementLabel($sensor->type)
-            ->labels($sensordata->reverse()->pluck('created_at'))
-            ->values($sensordata->reverse()->pluck('value'))
+            ->labels($chartSensorData->pluck('created_at'))
+            ->values($chartSensorData->pluck('value'))
             ->responsive(true);
 
-        return view('sensor.show', [ 'sensor' => $sensor, 'sensordata' => $sensordata, 'chart' => $chart ]);
+        return view('sensor.show', [ 'sensor' => $sensor, 'latestData' => $latestData, 'sensordata' => $sensordata, 'chart' => $chart ]);
     }
 
     /**

--- a/app/Sensor.php
+++ b/app/Sensor.php
@@ -4,8 +4,6 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Traits\LogsActivity;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
 
 class Sensor extends Model 
 {
@@ -69,7 +67,9 @@ class Sensor extends Model
      */
     public function getLatestDataAttribute()
     {
-        return $this->hasOne('App\SensorData')->latest()->first() ?? (object)[];
+        return SensorData::whereRaw('id = (SELECT MAX(id)
+                                                    FROM sensor_data
+                                                    WHERE sensor_id = ?)', [$this->id])->first() ?? (object)[];
     }
     
     /**

--- a/resources/views/device/show.blade.php
+++ b/resources/views/device/show.blade.php
@@ -28,11 +28,11 @@
                                 <tbody>
                                 <tr>
                                     <td>Site:</td>
-                                    <td><a href="{{-- TODO route('site.show', $device->site->id) --}}">{{ $device->site->name ?? 'null' }}</a></td>
+                                    <td><a href="{{  route('site.show', $device->site->id) }}">{{ $device->site->name ?? 'null' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td>Location:</td>
-                                    <td><a href="{{-- TODO route('location.show', $device->location_id) --}}">{{ $device->location->name ?? 'null' }}</a></td>
+                                    <td><a href="{{  route('location.show', $device->location_id) }}">{{ $device->location->name ?? 'null' }}</a></td>
                                 </tr>
                                 <tr>
                                     <td>Registered:</td>
@@ -40,8 +40,12 @@
                                 </tr>
                                 <tr>
                                     <td>Updated:</td>
-                                    <td>{{ $device->updated_at }}</td>
+                                    <td>{{ $device->updatedAtHuman }}</td>
                                 </tr>
+								<tr>
+									<td>Last Communication:</td>
+									<td>{{ $device->lastNetworkUpdateAtDetailed }}</td>
+								</tr>
                                 <tr>
                                     <td>UUID:</td>
                                     <td>{{ $device->uuid }}</td>
@@ -75,18 +79,6 @@
                                     <td>{{ $device->error_msg }}</td>
                                 </tr>
                                 <tr>
-                                    <td>Open Switch:</td>
-                                    <td>{{ $device->limitsw_open }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Closed Switch:</td>
-                                    <td>{{ $device->limitsw_closed }}</td>
-                                </tr>
-                                <tr>
-                                    <td>Timezone:</td>
-                                    <td>{{ $device->timezone }}</td>
-                                </tr>
-                                <tr>
                                     <td>Update rate:</td>
                                     <td>{{ $device->update_rate }} seconds</td>
                                 </tr>
@@ -108,11 +100,11 @@
                                 </tr>
                                 <tr>
                                     <td>Open Time:</td>
-                                    <td>{{ $device->open_time }}</td>
+                                    <td>{{ $device->openTimeHuman }}</td>
                                 </tr>
                                 <tr>
                                     <td>Close Time:</td>
-                                    <td>{{ $device->close_time }}</td>
+                                    <td>{{ $device->closeTimeHuman }}</td>
                                 </tr>
                                 </tbody>
                             </table>
@@ -151,14 +143,15 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @foreach ($device->sensors as $sensor)
-                                    <tr>
-                                        <td><a href="{{ route('sensor.show', $sensor->id) }}">{{ $sensor->name }}</a></td>
-                                        <td>{{ $sensor->type }}</td>
-                                        <td><a href="{{ route('sensordata.show', $sensor->latest_data->id ?? 0) }}">{{ $sensor->latest_data->value ?? 'null' }}</a></td>
-                                        <td>{{ $sensor->latest_data->updated_at ?? 'null' }} GMT</td>
-                                    </tr>
-                                    @endforeach
+									@foreach ($device->sensors as $sensor)
+                                        <?php $latestData = $sensor->latest_data; ?>
+										<tr>
+											<td><a href="{{ route('sensor.show', $sensor->id) }}">{{ $sensor->name }}</a></td>
+											<td>{{ $sensor->type }}</td>
+											<td><a href="{{ route('sensordata.show', $latestData->id ?? 0) }}">{{ $latestData->value ?? 'null' }}</a></td>
+											<td>{{ $latestData->updated_at ?? 'null' }} GMT</td>
+										</tr>
+									@endforeach
                                 </tbody>
                             </table>
                         </div>

--- a/resources/views/sensor/show.blade.php
+++ b/resources/views/sensor/show.blade.php
@@ -30,7 +30,7 @@
                                 </tr>
                                 <tr>
                                     <td>Latest Value:</td>
-                                    <td><a href="{{ route('sensordata.show', $sensor->latest_data->id ?? '0') }}">{{ $sensor->latest_data->value ?? 'null' }}</a></td>
+                                    <td><a href="{{ route('sensordata.show', $latestData->id ?? '0') }}">{{ $latestData->value ?? 'null' }}</a></td>
                                 </tr>
                                 </tbody>
                             </table>


### PR DESCRIPTION
Overview: Removed redundant queries from device.show, sensor controller, and
sensor.show. Added multiple accessors to device to be able to get
formatted times of updated_at, created_at, open_time, and close_time.

Analysis:
- Average
 Before: 55ms per query
 After: .40ms per query
Example of the two queries:
![sensor latest data query](https://user-images.githubusercontent.com/16866862/32683882-9a4b466e-c633-11e7-9d08-933f4abc8467.JPG)

- device.show
 Before: Six queries per sensor
 After: One query per sensor
- sensor.show
 Before: Four sensor_data queries
 After: One sensor_data query
