### PR TITLE
Add validation rules to replace the use of the string rule

### DIFF
--- a/app/Device.php
+++ b/app/Device.php
@@ -38,9 +38,8 @@ class Device extends Model
      */
     protected $fillable = [
         'name', 'location_id', 'uuid', 'version', 'hostname', 'ip', 'mac_address', 
-        'time', 'cover_command', 'cover_status', 'error_msg', 'limitsw_open', 'limitsw_closed',
-        'light_in', 'light_out', 'update_rate', 'image_rate', 'sensor_rate', 
-        'open_time', 'close_time', 'last_network_update_at',
+        'time', 'cover_command', 'cover_status', 'error_msg', 'update_rate',
+        'image_rate', 'sensor_rate', 'open_time', 'close_time', 'last_network_update_at',
     ];
     
     /**
@@ -57,9 +56,8 @@ class Device extends Model
      */
     protected static $logAttributes = [
         'name', 'location_id', 'uuid', 'version', 'hostname', 'ip', 'mac_address', 
-        'time', 'cover_status', 'error_msg', 'limitsw_open', 'limitsw_closed', 
-        'light_in', 'light_out', 'update_rate', 'image_rate', 'sensor_rate', 
-        'open_time', 'close_time'
+        'time', 'cover_command', 'cover_status', 'error_msg',
+        'update_rate', 'image_rate', 'sensor_rate', 'open_time', 'close_time'
     ];
     
     /**

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -46,16 +46,16 @@ class ApiController extends Controller
     {
         // Validate the request
         $validator = Validator::make($request->all(), [
-            'uuid'          => 'required|string|max:255|exists:devices,uuid',
-            'token'         => 'required|string|max:60|exists:devices,token',
-            'version'       => 'nullable|string|max:32',
-            'hostname'      => 'nullable|string|max:255',
+            'uuid'          => 'required|size:36|uuid|exists:devices,uuid',
+            'token'         => 'required|max:60|alpha_num|exists:devices,token',
+            'version'       => 'nullable|max:32|version',
+            'hostname'      => 'nullable|max:255|url',
             'ip'            => 'nullable|ip',
-            'mac_address'   => 'nullable|string|min:12|max:12',
+            'mac_address'   => 'nullable|size:12|mac',
             'time'          => 'nullable|date',
-            'cover_status'  => 'nullable|string|max:32',
+            'cover_status'  => 'nullable|alpha|max:7|in:opening,closing,open,closed,locked,error',
             'cover_command'  => 'nullable|alpha|max:5|in:open,close',
-            'error_msg'     => 'nullable|string',
+            'error_msg'     => 'nullable|max:1000|error_string',
         ])->validate();
         
         // Get the device record.
@@ -94,11 +94,11 @@ class ApiController extends Controller
     {
         // Validate the request
         $validator = Validator::make($request->all(), [
-            'uuid'          => 'required|string|max:255|exists:devices,uuid',
-            'token'         => 'required|string|max:60|exists:devices,token',
-            'sensor_data.*.name'   => 'required|max:190',
-            'sensor_data.*.type'   => 'required|max:190',
-            'sensor_data.*.value'  => 'required|max:190',
+            'uuid'          => 'required|size:36|uuid|exists:devices,uuid',
+            'token'         => 'required|max:60|alpha_num|exists:devices,token',
+            'sensor_data.*.name'   => 'required|min:2|max:190|name',
+            'sensor_data.*.type'   => 'required|max:190|type_name',
+            'sensor_data.*.value'  => 'required|max:190|value_string',
         ])->validate();
         
         // Get the device record.
@@ -147,8 +147,8 @@ class ApiController extends Controller
     {
         // Validate the request.
         $validator = Validator::make($request->all(), [
-            'uuid' => 'required|string|max:255',
-            'challenge' => 'required|string|min:6',
+            'uuid' => 'required|size:36|uuid',
+            'challenge' => 'required|min:6|string',
         ])->validate();
         
         // If challenge string doesnt match then send 401 unauthorized.
@@ -199,8 +199,8 @@ class ApiController extends Controller
     public function image(Request $request) {
         // Validate the request.
         $validator = Validator::make($request->all(), [
-            'uuid'          => 'required|string|max:255|exists:devices,uuid',
-            'token'         => 'required|string|max:60|exists:devices,token',
+            'uuid'          => 'required|size:36|uuid|exists:devices,uuid',
+            'token'         => 'required|max:60|alpha_num|exists:devices,token',
             'image'         => 'required|image|mimes:jpeg,jpg,png,gif|max:2048',
         ])->validate();
         

--- a/app/Http/Controllers/SensorController.php
+++ b/app/Http/Controllers/SensorController.php
@@ -50,9 +50,9 @@ class SensorController extends Controller
     public function store(Request $request)
     {
         request()->validate([
-            'device_id' => 'required|integer|exists:devices,id',
-            'name' => 'required|name|max:190',
-            'type' => 'required|name|max:190'
+            'device_id' => 'required|integer|digits_between:1,10|exists:devices,id',
+            'name' => 'required|min:2|max:190|name',
+            'type' => 'required|max:190|type_name'
         ]);
 
         $query = Sensor::create($request->all());
@@ -106,9 +106,9 @@ class SensorController extends Controller
     public function update(Request $request, $id)
     {
         request()->validate([
-            'device_id' => 'required|integer|exists:devices,id',
-            'name' => 'required|name|max:190',
-            'type' => 'required|name|max:190'
+            'device_id' => 'required|integer|digits_between:1,10|exists:devices,id',
+            'name' => 'required|min:2|max:190|name',
+            'type' => 'required|max:190|type_name'
         ]);
         $query = Sensor::findOrFail($id)->update($request->all());
         return redirect()->route('sensor.show', $id)

--- a/app/Http/Controllers/SensorDataController.php
+++ b/app/Http/Controllers/SensorDataController.php
@@ -48,8 +48,8 @@ class SensorDataController extends Controller
     public function store(Request $request)
     {
         request()->validate([
-            'sensor_id' => 'required|integer|exists:sensors,id',
-            'value' => 'required|string|max:190'
+            'sensor_id' => 'required|integer|digits_between:1,10|exists:sensors,id',
+            'value' => 'required|max:190|value_string'
         ]);
 
         $query = SensorData::create($request->all());
@@ -94,8 +94,8 @@ class SensorDataController extends Controller
     public function update($id)
     {
         request()->validate([
-            'sensor_id' => 'required|integer|exists:sensors,id',
-            'value' => 'required|string|max:190'
+            'sensor_id' => 'required|integer|digits_between:1,10|exists:sensors,id',
+            'value' => 'required|max:190|value_string'
         ]);
         $query = SensorData::findOrFail($id)->update($request->all());
         return redirect()->route('sensordata.show', $id)

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -46,7 +46,7 @@ class SiteController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'name' => 'required|min:2|max:75|name|unique:sites,name',
+            'name' => 'required|min:2|max:190|name|unique:sites,name',
         ]);
         
         $site = Site::create(['name' => $request->name]);
@@ -95,7 +95,7 @@ class SiteController extends Controller
     public function update(Request $request, Site $site)
     {
         $request->validate([
-            'name' => 'required|min:2|max:75|name|unique:sites,name,'.$site->id,
+            'name' => 'required|min:2|max:190|name|unique:sites,name,'.$site->id,
         ]);
         
         $site->update(['name' => $request->name]);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -51,7 +51,7 @@ class UserController extends Controller
     public function store(Request $request)
     {
         request()->validate([
-            'name' => 'required|string|max:255',
+            'name' => 'required|min:2|max:190|full_name',
             'email' => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:8|confirmed',
             'role' => 'required|integer|max:3',
@@ -112,12 +112,12 @@ class UserController extends Controller
     public function update(Request $request, $id)
     {
         request()->validate([
-            'name' => 'required|string|max:255',
+            'name' => 'required|min:2|max:190|full_name',
             'email' => 'required|string|email|max:255|unique:users,email,'.$id,
             'password' => 'sometimes|nullable|min:8|confirmed',
             'role' => 'required|integer|max:3',
             'phone' => 'numeric|phone|nullable',
-            'preferred_device_id' => 'numeric|nullable|digits_between:1,10|exists:devices,id',
+            'preferred_device_id' => 'nullable|integer|digits_between:1,10|exists:devices,id',
         ]);
         
         $query = User::findOrFail($id);

--- a/app/Http/Requests/EditDevice.php
+++ b/app/Http/Requests/EditDevice.php
@@ -27,7 +27,7 @@ class EditDevice extends FormRequest
     {
         //TODO figure out way for unique location names for each specific site
         return [
-            'name' => 'sometimes|nullable|min:2|max:75|name',
+            'name' => 'sometimes|nullable|min:2|max:190|name',
             'open_time' => 'sometimes|nullable|date_format:H:i',
             'close_time' => 'sometimes|nullable|date_format:H:i',
             'update_rate' => 'sometimes|nullable|integer|digits_between:1,7',
@@ -54,11 +54,11 @@ class EditDevice extends FormRequest
             return !$input->new_location_name && $input->location_id;
         });
     
-        $validator->sometimes('new_site_name', 'bail|min:2|max:75|name|unique:sites,name', function ($input) {
+        $validator->sometimes('new_site_name', 'bail|min:2|max:190|name|unique:sites,name', function ($input) {
             return !$input->site_id && $input->name;
         });
     
-        $validator->sometimes('new_location_name', 'bail|min:2|max:75|name|unique:locations,name', function ($input) {
+        $validator->sometimes('new_location_name', 'bail|min:2|max:190|name|unique:locations,name', function ($input) {
             return !$input->location_id && $input->name;
         });
         
@@ -76,7 +76,9 @@ class EditDevice extends FormRequest
             'name.required' => 'A device name is required',
             'site_id.required' => 'A site is required',
             'new_site_name.required' => 'A site is required',
+            'new_site_name.min'  => 'The new site must be at least 2 characters',
             'location_id.required' => 'A location is required',
+            'location_id.min'  => 'The new location must be at least 2 characters',
             'new_location_name.required' => 'A location is required',
             'open_time.required'  => 'A open time for the device is required',
             'open_time.date_format:H:i'  => 'A open time must be in the format hour:minutes',

--- a/app/Http/Requests/EditLocation.php
+++ b/app/Http/Requests/EditLocation.php
@@ -39,10 +39,10 @@ class EditLocation extends FormRequest
         $validator = parent::getValidatorInstance();
         
         $validator->sometimes('site', 'integer|digits_between:1,10|exists:sites,id', function ($input) {
-            return !$input->new_site_name;
+            return !$input->new_site_name && $input->site;
         });
         
-        $validator->sometimes('new_site_name', 'bail|min:2|max:75|name|unique:sites,name', function ($input) {
+        $validator->sometimes('new_site_name', 'bail|min:2|max:190|name|unique:sites,name', function ($input) {
             return !$input->site;
         });
         
@@ -59,6 +59,7 @@ class EditLocation extends FormRequest
         return [
             'name.required' => 'A location name is required',
             'new_site_name.unique'  => 'The site name must be unique',
+            'new_site_name.min'  => 'The new site must be at least 2 characters',
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,11 +34,74 @@ class AppServiceProvider extends ServiceProvider
     
         //Validator rule for names
         Validator::extend('name', function($attribute, $value, $parameters, $validator) {
-            return preg_match('#(^[a-zA-Z0-9])([\w\-\.\' ]*)([\w\-\.\']$)#', $value);
+            return preg_match('#(^[[:alnum:]])([\w\-\.\' ]*)([\w\-\.\']$)#', $value);
         });
     
         Validator::replacer('name', function($message, $attribute, $rule, $parameters) {
             return str_replace(':attribute', $attribute, ':attribute is invalid you can only use letters, numbers, underscores, dashes, spaces, periods and it must start with a letter or number');
+        });
+    
+        //Validator rule for user full names
+        Validator::extend('full_name', function($attribute, $value, $parameters, $validator) {
+            return preg_match('#(^[[:alpha:]])([[:alpha:]\_\-\. ]*)([[:alpha:]\_\-\.]$)#', $value);
+        });
+    
+        Validator::replacer('full_name', function($message, $attribute, $rule, $parameters) {
+            return str_replace(':attribute', $attribute, ':attribute is invalid you can only use letters, underscores, dashes, spaces, periods and it must start with a letter');
+        });
+    
+        //Validator rule for values
+        Validator::extend('value_string', function($attribute, $value, $parameters, $validator) {
+            return preg_match('#(^[[:alnum:]\+\-])([\w\+\-\.\'\, ]*$)#', $value);
+        });
+    
+        Validator::replacer('value_string', function($message, $attribute, $rule, $parameters) {
+            return str_replace(':attribute', $attribute, ':attribute is invalid you can only use alphanumerics spaces +-_.\', and it must start with a alphanumeric or a plus or minus');
+        });
+    
+        //Validator rule for types
+        Validator::extend('type_name', function($attribute, $value, $parameters, $validator) {
+            return preg_match('#(^[[:alpha:]\_])([\w]*$)#', $value);
+        });
+    
+        Validator::replacer('type_name', function($message, $attribute, $rule, $parameters) {
+            return str_replace(':attribute', $attribute, ':attribute is invalid you can only use alphanumerics, underscores and it must start with a letter or underscore');
+        });
+    
+        //Validator rule for error messages
+        Validator::extend('error_string', function($attribute, $value, $parameters, $validator) {
+            return preg_match('#(^[\w])([\w\-\.\'\, ]*$)#', $value);
+        });
+    
+        Validator::replacer('error_string', function($message, $attribute, $rule, $parameters) {
+            return str_replace(':attribute', $attribute, ':attribute is invalid you can only use alphanumerics spaces _.\', and it must start with a alphanumeric or underscore');
+        });
+    
+        //Validator rule for mac addresses
+        Validator::extend('mac', function($attribute, $value, $parameters, $validator) {
+            return preg_match('#^(([[:xdigit:]]{2}){6})$#', $value);
+        });
+    
+        Validator::replacer('mac', function($message, $attribute, $rule, $parameters) {
+            return str_replace(':attribute', $attribute, ':attribute is invalid you must provide a valid mac address like 000000000000');
+        });
+    
+        //Validator rule for versions
+        Validator::extend('version', function($attribute, $value, $parameters, $validator) {
+            return preg_match('#(^[0-9])(([\+\-\.][[:alnum:]]+)*$)#', $value);
+        });
+    
+        Validator::replacer('version', function($message, $attribute, $rule, $parameters) {
+            return str_replace(':attribute', $attribute, ':attribute is invalid you can only use alphanumerics +-. and it must start with a number and end with an alphanumeric');
+        });
+    
+        //Validator rule for uuid
+        Validator::extend('uuid', function($attribute, $value, $parameters, $validator) {
+            return preg_match('#^([[:xdigit:]]{8})(-[[:xdigit:]]{4}){3}(-[[:xdigit:]]{12})$#', $value);
+        });
+    
+        Validator::replacer('uuid', function($message, $attribute, $rule, $parameters) {
+            return str_replace(':attribute', $attribute, ':attribute is invalid you must provide five groups of hexadecimals in the form 8-4-4-4-12');
         });
     }
 


### PR DESCRIPTION
Added validation rules for the following:
- user full names
- sensor data values
- sensor types
- device errors
- mac addresses
- versioning
- uuids

Updated the different controller's validators to use these new rules. Fixes issue #93 

Add the device tables cover_command to be logged. This way user actions to open or close the device will be logged.