### PR TITLE
Update date/times formatting throughout site

### DIFF
--- a/app/DataTables/ActivityLogDataTable.php
+++ b/app/DataTables/ActivityLogDataTable.php
@@ -3,6 +3,7 @@
 namespace App\DataTables;
 
 use App\User;
+use Illuminate\Support\Facades\Auth;
 use Yajra\DataTables\Services\DataTable;
 use Spatie\Activitylog\Models\Activity;
 
@@ -24,6 +25,12 @@ class ActivityLogDataTable extends DataTable
             })
             ->editColumn('properties', function ($activity) {
                 return $activity->properties;
+            })
+            ->editColumn('created_at', function ($activity) {
+                if ($activity->created_at->diffInDays() > 0)
+                    return $activity->created_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+                else
+                    return $activity->created_at->diffForHumans();
             })
             ->rawColumns(['causer_id', 'subject_id', 'properties']);
     }

--- a/app/DataTables/DevicesDataTable.php
+++ b/app/DataTables/DevicesDataTable.php
@@ -29,7 +29,7 @@ class DevicesDataTable extends DataTable
                 return $device->update_rate . '/' . $device->image_rate .'/' . $device->sensor_rate;
             })
             ->editColumn('updated_at', function ($device) {
-                return (is_object($device->updated_at) ? $device->updated_at->diffForHumans() : 'never');
+                return (is_object($device->updated_at) ? $device->updatedAtHuman : 'null');
             })
             ->blacklist([ 'location', 'site', 'rates' ])
             ->rawColumns([ 'name' ]);
@@ -74,7 +74,7 @@ class DevicesDataTable extends DataTable
             'open_time',
             'close_time',
             'rates',
-            [ 'data' => 'updated_at', 'name' => 'updated_at', 'title' => 'Updated' ]
+            [ 'data' => 'updated_at', 'name' => 'updated_at', 'title' => 'Updated At' ]
         ];
     }
 

--- a/app/DataTables/UsersDataTable.php
+++ b/app/DataTables/UsersDataTable.php
@@ -22,6 +22,12 @@ class UsersDataTable extends DataTable
             ->editColumn('role', function(User $user) {
                 return $user->roleString();
             })
+            ->editColumn('updated_at', function ($user) {
+                return $user->updatedAtHuman;
+            })
+            ->editColumn('created_at', function ($user) {
+                return $user->createdAtHuman;
+            })
             ->addColumn('action', 'user.action')
             ->blacklist([ 'action' ])
             ->rawColumns([ 'name', 'action' ])

--- a/app/Device.php
+++ b/app/Device.php
@@ -201,47 +201,55 @@ class Device extends Model
     }
     
     /**
-     * Accessor: Get the last time the server received and update call from the device converted to a
-     * user friendly format. The format is Month day 12hour:mins am/pm and will be in the user's preferred timezone
+     * Accessor: Get the last time the server received an update call from the device in seconds/minutes/hours since
+     * update or converted to user friendly readable format.
+     * If the time is less then a day old then display time since it last updated
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
      *
      * @return string
      */
     public function getLastNetworkUpdateAtHumanAttribute()
     {
-        return $this->last_network_update_at->setTimezone(Auth::user()->timezone)->format('M j g:i a');
+        if ($this->last_network_update_at->diffInDays() > 0)
+            return $this->last_network_update_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->last_network_update_at->diffForHumans();
     }
     
     /**
-     * Accessor: Get the last time the server received and update call from the device converted to a
-     * user friendly detailed format. The format is Month day, year 12hour:mins am/pm and will be in the user's preferred timezone
+     * Accessor: Get the devices last update time in seconds/minutes/hours since update or converted to user friendly
+     * readable format.
+     * If the time is less then a day old then display time since it last update
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
      *
-     * @return string
-     */
-    public function getLastNetworkUpdateAtDetailedAttribute()
-    {
-        return $this->last_network_update_at->setTimezone(Auth::user()->timezone)->format('M j, Y g:i a');
-    }
-    
-    /**
-     * Accessor: Get the devices last update time converted to a
-     * user friendly format. The format is Month day, year 12hour:mins am/pm and will be in the user's preferred timezone
      *
      * @return string
      */
     public function getUpdatedAtHumanAttribute()
     {
-        return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M j, Y g:i a');
+        if ($this->updated_at->diffInDays() > 0)
+            return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->updated_at->diffForHumans();
     }
     
     /**
-     * Accessor: Get the devices created at time converted to a
-     * user friendly format. The format is Month day, year 12hour:mins am/pm and will be in the user's preferred timezone
+     * Accessor: Get the devices creation time in seconds/minutes/hours since creation or converted to user friendly
+     * readable format.
+     * If the time is less then a day old then display time since its creation
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
      *
      * @return string
      */
     public function getCreatedAtHumanAttribute()
     {
-        return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M j, Y g:i a');
+        if ($this->created_at->diffInDays() > 0)
+            return $this->created_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->created_at->diffForHumans();
     }
     
     /**

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -48,9 +48,9 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'name' => 'required|string|max:255',
+            'name' => 'required|min:2|max:190|full_name',
             'email' => 'required|string|email|max:255|unique:users',
-            'password' => 'required|string|min:6|confirmed',
+            'password' => 'required|string|min:8|confirmed',
         ]);
     }
 

--- a/app/Location.php
+++ b/app/Location.php
@@ -3,8 +3,8 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
 use Spatie\Activitylog\Traits\LogsActivity;
+use Illuminate\Support\Facades\Auth;
 
 class Location extends Model
 {
@@ -75,5 +75,41 @@ class Location extends Model
     public function scopeBySite($query, $site_id)
     {
         return $query->where('site_id', $site_id);
+    }
+    
+    /**
+     * Accessor: Get the location's last update time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since it last updated
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getUpdatedAtHumanAttribute()
+    {
+        if ($this->updated_at->diffInDays() > 0)
+            return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->updated_at->diffForHumans();
+    }
+    
+    /**
+     * Accessor: Get the location's creation time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since creation
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getCreatedAtHumanAttribute()
+    {
+        if ($this->created_at->diffInDays() > 0)
+            return $this->created_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->created_at->diffForHumans();
     }
 }

--- a/app/Sensor.php
+++ b/app/Sensor.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Traits\LogsActivity;
+use Illuminate\Support\Facades\Auth;
 
 class Sensor extends Model 
 {
@@ -130,5 +131,41 @@ class Sensor extends Model
             ->whereRaw("created_at > DATE_SUB(NOW(), INTERVAL 1 YEAR)")
             ->groupBy("date")
             ->get();
+    }
+    
+    /**
+     * Accessor: Get the sensor's last update time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since it last updated
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getUpdatedAtHumanAttribute()
+    {
+        if ($this->updated_at->diffInDays() > 0)
+            return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->updated_at->diffForHumans();
+    }
+    
+    /**
+     * Accessor: Get the sensor's creation time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since creation
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getCreatedAtHumanAttribute()
+    {
+        if ($this->created_at->diffInDays() > 0)
+            return $this->created_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->created_at->diffForHumans();
     }
 }

--- a/app/SensorData.php
+++ b/app/SensorData.php
@@ -54,4 +54,40 @@ class SensorData extends Model
     {
         return $this->belongsTo('App\Sensor');
     }
+    
+    /**
+     * Accessor: Get the sensor data's last update time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since it last updated
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getUpdatedAtHumanAttribute()
+    {
+        if ($this->updated_at->diffInDays() > 0)
+            return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->updated_at->diffForHumans();
+    }
+    
+    /**
+     * Accessor: Get the sensor data's creation time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since creation
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getCreatedAtHumanAttribute()
+    {
+        if ($this->created_at->diffInDays() > 0)
+            return $this->created_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->created_at->diffForHumans();
+    }
 }

--- a/app/Site.php
+++ b/app/Site.php
@@ -3,8 +3,8 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
 use Spatie\Activitylog\Traits\LogsActivity;
+use Illuminate\Support\Facades\Auth;
 
 class Site extends Model
 {
@@ -63,5 +63,41 @@ class Site extends Model
     public function devices()
     {
         return $this->hasManyThrough('App\Device', 'App\Location');
+    }
+    
+    /**
+     * Accessor: Get the site's last update time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since it last updated
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getUpdatedAtHumanAttribute()
+    {
+        if ($this->updated_at->diffInDays() > 0)
+            return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->updated_at->diffForHumans();
+    }
+    
+    /**
+     * Accessor: Get the site's creation time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since creation
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getCreatedAtHumanAttribute()
+    {
+        if ($this->created_at->diffInDays() > 0)
+            return $this->created_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
+        else
+            return $this->created_at->diffForHumans();
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -165,7 +165,7 @@ class User extends Authenticatable
     public function getUpdatedAtHumanAttribute()
     {
         if ($this->updated_at->diffInDays() > 0)
-            return $this->updated_at->setTimezone($this->timezone)->format('M d, Y h:i a');
+            return $this->updated_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
         else
             return $this->updated_at->diffForHumans();
     }
@@ -183,7 +183,7 @@ class User extends Authenticatable
     public function getCreatedAtHumanAttribute()
     {
         if ($this->created_at->diffInDays() > 0)
-            return $this->created_at->setTimezone($this->timezone)->format('M d, Y h:i a');
+            return $this->created_at->setTimezone(Auth::user()->timezone)->format('M d, Y h:i a');
         else
             return $this->created_at->diffForHumans();
     }

--- a/app/User.php
+++ b/app/User.php
@@ -6,14 +6,12 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\Traits\LogsActivity;
-//use Spatie\Activitylog\Traits\CausesActivity;
 
 class User extends Authenticatable
 {
     use Notifiable;
     use SoftDeletes;
     use LogsActivity;
-    //use CausesActivity;
 
     /**
      * The attributes that should be mutated to dates.
@@ -152,5 +150,41 @@ class User extends Authenticatable
     public function preferredDevice()
     {
         return $this->hasOne('App\Device', 'id', 'preferred_device_id');
+    }
+    
+    /**
+     * Accessor: Get the user's last update time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since it last updated
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getUpdatedAtHumanAttribute()
+    {
+        if ($this->updated_at->diffInDays() > 0)
+            return $this->updated_at->setTimezone($this->timezone)->format('M d, Y h:i a');
+        else
+            return $this->updated_at->diffForHumans();
+    }
+    
+    /**
+     * Accessor: Get the user's creation time in seconds/minutes/hours since update or converted to user
+     * friendly readable format.
+     * If the time is less then a day old then display time since creation
+     * If the time is greater then a day old then display the time in the format of Month day, year 12hour:mins am/pm
+     * and using the user's preferred timezone
+     *
+     *
+     * @return string
+     */
+    public function getCreatedAtHumanAttribute()
+    {
+        if ($this->created_at->diffInDays() > 0)
+            return $this->created_at->setTimezone($this->timezone)->format('M d, Y h:i a');
+        else
+            return $this->created_at->diffForHumans();
     }
 }

--- a/resources/views/dashboard/device_list.blade.php
+++ b/resources/views/dashboard/device_list.blade.php
@@ -49,7 +49,7 @@
 							@default
 								<button class="btn btn-primary" type="button" data-array-pos="{{ $loop->index }}" data-device-id="{{ $device->id }}" disabled><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Error</button>
 						@endswitch
-						<button class="btn btn-primary" type="button" disabled><i class="fa fa-line-chart"></i> Graphs</button>
+						<a class="btn btn-primary" type="button" href="{{ route('device.show', $device->id) }}"><i class="fa fa-line-chart"></i> Graphs</a>
 						@if($device->actualCoverStatus() == 'locked')
 							<button class="btn btn-primary" type="button" data-array-pos="{{ $loop->index }}" data-device-id="{{ $device->id }}" data-command="unlock"><i class="fa fa-unlock" aria-hidden="true"></i> Unlock</button>
 						@elseif($device->actualCoverStatus() == 'open' || $device->actualCoverStatus() == 'closed')

--- a/resources/views/device/show.blade.php
+++ b/resources/views/device/show.blade.php
@@ -50,7 +50,7 @@
                                 </tr>
 								<tr>
 									<td>Last Communication:</td>
-									<td>{{ $device->lastNetworkUpdateAtDetailed }}</td>
+									<td>{{ $device->lastNetworkUpdateAtHuman }}</td>
 								</tr>
                                 <tr>
                                     <td>UUID:</td>
@@ -155,7 +155,7 @@
 											<td><a href="{{ route('sensor.show', $sensor->id) }}">{{ $sensor->name }}</a></td>
 											<td>{{ $sensor->type }}</td>
 											<td><a href="{{ route('sensordata.show', $latestData->id ?? 0) }}">{{ $latestData->value ?? 'null' }}</a></td>
-											<td>{{ $latestData->updated_at ?? 'null' }} GMT</td>
+											<td>{{ $latestData->createdAtHuman ?? 'null' }}</td>
 										</tr>
 									@endforeach
                                 </tbody>

--- a/resources/views/home/about.blade.php
+++ b/resources/views/home/about.blade.php
@@ -16,10 +16,7 @@
 						<p class="title">COMPUTER SCIENCE</p>
 						<p class="description">I'm a senior Computer Science student at the University of Idaho. My main focus and interests are cyber security and databases. In my free time I like to work on side projects ranging from mobile app development to video game development.</p>
 						<div class="social">
-							<a href="https://github.com"><i class="fa fa-github"></i></a>
-							<a href="https://keybase.io"><i class="fa fa-key"></i></a>
-							<a href="https://linkedin.com"><i class="fa fa-linkedin"></i></a>
-							<a href="https://facebook.com"><i class="fa fa-facebook"></i></a>
+							<a href="https://github.com/brec9824"><i class="fa fa-github"></i></a>
 						</div>
 					</div>
 				</div>

--- a/resources/views/location/show.blade.php
+++ b/resources/views/location/show.blade.php
@@ -62,7 +62,7 @@
 									@foreach ($devices as $device)
 										<tr>
 											<td><a href="{{ route('device.show', $device->id) }}">{{ $device->name }}</a></td>
-											<td>{{ is_object($device->updated_at) ? $device->updated_at->diffForHumans() : 'never' }}</td>
+											<td>{{ is_object($device->updated_at) ? $device->updatedAtHuman : 'never' }}</td>
 										</tr>
 									@endforeach
 									</tbody>

--- a/resources/views/sensor/show.blade.php
+++ b/resources/views/sensor/show.blade.php
@@ -88,7 +88,7 @@
                                     <tr>
                                         <td><a href="{{ route('sensordata.show', $data->id) }}">{{ $data->id }}</a></td>
                                         <td>{{ $data->value }}</td>
-                                        <td>{{ $data->created_at }} GMT</td>
+                                        <td>{{ $data->createdAtHuman }}</td>
                                     </tr>
                                     @endforeach
                                 </tbody>

--- a/resources/views/sensordata/show.blade.php
+++ b/resources/views/sensordata/show.blade.php
@@ -33,12 +33,8 @@
                                     <td>{{ $sensordata->value }}</td>
                                 </tr>
                                 <tr>
-                                    <td>Updated At:</td>
-                                    <td>{{ $sensordata->updated_at }} GMT</td>
-                                </tr>
-                                <tr>
                                     <td>Created At:</td>
-                                    <td>{{ $sensordata->created_at }} GMT</td>
+                                    <td>{{ $sensordata->createdAtHuman }}</td>
                                 </tr>
                                 </tbody>
                             </table>

--- a/resources/views/site/show.blade.php
+++ b/resources/views/site/show.blade.php
@@ -20,6 +20,10 @@
 										<td>ID:</td>
 										<td>{{ $site->id }}</td>
 									</tr>
+									<tr>
+										<td>Created At:</td>
+										<td>{{ $site->createdAtHuman }}</td>
+									</tr>
 									</tbody>
 								</table>
 							</div>
@@ -51,14 +55,14 @@
 									<thead>
 									<tr>
 										<td>Name:</td>
-										<td>Updated:</td>
+										<td>Updated At:</td>
 									</tr>
 									</thead>
 									<tbody>
 									@foreach ($locations as $location)
 										<tr>
 											<td><a href="{{ route('location.show', $location->id) }}">{{ $location->name }}</a></td>
-											<td>{{ is_object($location->updated_at) ? $location->updated_at->diffForHumans() : 'never' }}</td>
+											<td>{{ is_object($location->updated_at) ? $location->updatedAtHuman : 'never' }}</td>
 										</tr>
 									@endforeach
 									</tbody>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -32,11 +32,11 @@
                                 </tr>
                                 <tr>
                                     <td>Registered since:</td>
-                                    <td>{{ $user->created_at }}</td>
+                                    <td>{{ $user->createdAtHuman }}</td>
                                 </tr>
                                 <tr>
                                     <td>Updated at:</td>
-                                    <td>{{ $user->updated_at }}</td>
+                                    <td>{{ $user->updatedAtHuman }}</td>
                                 </tr>
                                 <tr>
                                     <td>E-mail:</td>


### PR DESCRIPTION
Updated all date/times to display in the format x min/hr/day ago if they where less then a day old and display in the format month day, year 12hour:mins am/pm if older then a day. 

Set the dashboard device list graph buttons to link to their specific device's show page.

Completes part of issue #115 