### PR TITLE
Prune sensordata table for entries older than a year

### DIFF
--- a/app/Console/Commands/CleanSensordata.php
+++ b/app/Console/Commands/CleanSensordata.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\SensorData;
+use Illuminate\Console\Command;
+
+class CleanSensordata extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sensordata:clean';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clean up old records from the sensordata table.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->comment('Cleaning sensordata table...');
+        
+        $maxAgeInDays = config('sensordata.delete_records_older_than_days', 365);
+        $cutOffDate = Carbon::now()->subDays($maxAgeInDays)->format('Y-m-d H:i:s');
+        $amountDeleted = Sensordata::where('created_at', '<', $cutOffDate)->delete();
+        
+        $this->info("Deleted {$amountDeleted} record(s) from the activity log.");
+        
+        $this->comment('All done!');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,6 +26,8 @@ class Kernel extends ConsoleKernel
     {
         // Prune the activity log for entries older than 30 days.
         $schedule->command('activitylog:clean')->daily();
+        // Prune the sensordata table for entries older than 365 days.
+        $schedule->command('sensordata:clean')->daily();
     }
 
     /**


### PR DESCRIPTION
This PR prunes the sensordata table for entries older than a year. Part of #115. Ready for review/merge/delete.